### PR TITLE
Method to get medium publications a user can contribute to

### DIFF
--- a/lib/medium_sdk/client.rb
+++ b/lib/medium_sdk/client.rb
@@ -44,6 +44,21 @@ module MediumSdk
       return body_key(res, 'data')
     end
 
+    def contributing_publications(user_id = nil)
+      publications = []
+      user_id = me_id if user_id.nil?
+      all_publications = user_publications
+      all_publications_ids = all_publications.map { |x| x["id"] }
+      all_publications_ids.each do |pub_id|
+        publication_contributors(pub_id).each do |contributor|
+          if contributor["userId"] == user_id && contributor["role"] == "editor"
+            publications << all_publications.select {|pub| pub["id"] == contributor["publicationId"] }
+          end
+        end 
+      end
+      return publications.flatten
+    end
+
     def post(post)
       url = ''
       if post.key? :publicationId

--- a/lib/medium_sdk/client.rb
+++ b/lib/medium_sdk/client.rb
@@ -47,7 +47,7 @@ module MediumSdk
     def contributing_publications(user_id = nil)
       publications = []
       user_id = me_id if user_id.nil?
-      all_publications = user_publications
+      all_publications = user_publications(user_id)
       all_publications_ids = all_publications.map { |x| x["id"] }
       all_publications_ids.each do |pub_id|
         publication_contributors(pub_id).each do |contributor|


### PR DESCRIPTION
Inspired from the medium wordpress plugin. It would make sense if you can get the list of publications a user can contribute to.
Since there isn't a direct api available, this involves iterating through each user publications and see whether he has editor privilege. 

this came handy for the project i am working on. Just in case this proves helpful for someone else in future.